### PR TITLE
Create GitHub Actions to build and publish multiarch image to ghcr.io

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,38 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/mnorrsken/whatsmyip:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Add GitHub Actions workflow to build and publish Docker image to ghcr.io

* Create `.github/workflows/docker-image.yml` to define the workflow
* Set up QEMU for multiarch builds using `docker/setup-qemu-action@v1`
* Set up Docker Buildx using `docker/setup-buildx-action@v1`
* Authenticate with GitHub Container Registry using `docker/login-action@v1`
* Build and push Docker image to `ghcr.io/mnorrsken/whatsmyip:latest` for `linux/amd64` and `linux/arm64` platforms
* Trigger workflow on push and pull request events to the `main` branch

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mnorrsken/whatsmyip/pull/2?shareId=ddfde5e0-bbeb-4f77-b79a-42f0945ece2a).